### PR TITLE
[DEVOPS-2407] removed provider information

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_version = ">= 0.14"
-
-  required_providers {
-    archive = "~> 1"
-    aws     = "~> 3"
-  }
-}


### PR DESCRIPTION
# [DEVOPS-2407]

> Remvoed the providers.tf file as it is incompatible with the AWS 4.29.0 provider upgrade and all our other modules do not specify the required providers.

[DEVOPS-2407]: https://lendable-uk.atlassian.net/browse/DEVOPS-2407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ